### PR TITLE
require futures 0.1.15 at a minimum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ Timeouts and intervals for futures.
 """
 
 [dependencies]
-futures = "0.1"
+futures = "0.1.15"


### PR DESCRIPTION
You rely on `AtomicTask` from `futures`, which has been introduced in version 0.1.15. Earlier versions of `futures` will cause a compilation error.