### PR TITLE
convert to futures 0.2 (alpha)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ Timeouts and intervals for futures.
 """
 
 [dependencies]
-futures = "0.1.15"
+futures = "0.2.0-alpha"

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -30,6 +30,7 @@ pub trait FutureExt: Future + Sized {
     ///
     /// use std::time::Duration;
     /// use futures::prelude::*;
+    /// use futures::executor::block_on;
     /// use futures_timer::FutureExt;
     ///
     /// # fn long_future() -> futures::future::FutureResult<(), std::io::Error> {
@@ -40,7 +41,7 @@ pub trait FutureExt: Future + Sized {
     ///     let future = long_future();
     ///     let timed_out = future.timeout(Duration::from_secs(1));
     ///
-    ///     match timed_out.wait() {
+    ///     match block_on(timed_out) {
     ///         Ok(item) => println!("got {:?} within enough time!", item),
     ///         Err(_) => println!("took too long to produce the item"),
     ///     }
@@ -86,16 +87,16 @@ impl<F> Future for Timeout<F>
     type Item = F::Item;
     type Error = F::Error;
 
-    fn poll(&mut self) -> Poll<F::Item, F::Error> {
-        match self.future.poll()? {
-            Async::NotReady => {}
+    fn poll(&mut self, cx: &mut task::Context) -> Poll<F::Item, F::Error> {
+        match self.future.poll(cx)? {
+            Async::Pending => {}
             other => return Ok(other)
         }
 
-        if self.timeout.poll()?.is_ready() {
+        if self.timeout.poll(cx)?.is_ready() {
             Err(io::Error::new(io::ErrorKind::TimedOut, "future timed out").into())
         } else {
-            Ok(Async::NotReady)
+            Ok(Async::Pending)
         }
     }
 }
@@ -142,20 +143,20 @@ impl<S> Stream for TimeoutStream<S>
     type Item = S::Item;
     type Error = S::Error;
 
-    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
-        match self.stream.poll() {
-            Ok(Async::NotReady) => {}
+    fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<S::Item>, S::Error> {
+        match self.stream.poll_next(cx) {
+            Ok(Async::Pending) => {}
             other => {
                 self.timeout.reset(self.dur);
                 return other
             }
         }
 
-        if self.timeout.poll()?.is_ready() {
+        if self.timeout.poll(cx)?.is_ready() {
             self.timeout.reset(self.dur);
             Err(io::Error::new(io::ErrorKind::TimedOut, "stream item timed out").into())
         } else {
-            Ok(Async::NotReady)
+            Ok(Async::Pending)
         }
     }
 }

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -58,9 +58,9 @@ impl Stream for Interval {
     type Item = ();
     type Error = io::Error;
 
-    fn poll(&mut self) -> Poll<Option<()>, io::Error> {
-        if self.delay.poll()?.is_not_ready() {
-            return Ok(Async::NotReady)
+    fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<()>, io::Error> {
+        if self.delay.poll(cx)?.is_pending() {
+            return Ok(Async::Pending)
         }
         let next = next_interval(delay::fires_at(&self.delay),
                                  Instant::now(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,8 @@ use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
 use std::sync::{Arc, Weak, Mutex};
 use std::time::Instant;
 
-use futures::task::AtomicTask;
-use futures::{Future, Async, Poll};
+use futures::task::AtomicWaker;
+use futures::{Future, Async, Poll, task};
 
 use arc_list::{ArcList, Node};
 use heap::{Heap, Slot};
@@ -129,12 +129,12 @@ struct Inner {
     list: ArcList<ScheduledTimer>,
 
     /// The blocked `Timer` task to receive notifications to the `list` above.
-    task: AtomicTask,
+    waker: AtomicWaker,
 }
 
 /// Shared state between the `Timer` and a `Delay`.
 struct ScheduledTimer {
-    task: AtomicTask,
+    waker: AtomicWaker,
 
     // The lowest bit here is whether the timer has fired or not, the second
     // lowest bit is whether the timer has been invalidated, and all the other
@@ -164,7 +164,7 @@ impl Timer {
         Timer {
             inner: Arc::new(Inner {
                 list: ArcList::new(),
-                task: AtomicTask::new(),
+                waker: AtomicWaker::new(),
             }),
             timer_heap: Heap::new(),
         }
@@ -210,7 +210,7 @@ impl Timer {
             *heap_timer.node.slot.lock().unwrap() = None;
             let bits = heap_timer.gen << 2;
             match heap_timer.node.state.compare_exchange(bits, bits | 0b01, SeqCst, SeqCst) {
-                Ok(_) => heap_timer.node.task.notify(),
+                Ok(_) => heap_timer.node.waker.wake(),
                 Err(_b) => {}
             }
         }
@@ -249,7 +249,7 @@ impl Timer {
 
     fn invalidate(&mut self, node: Arc<Node<ScheduledTimer>>) {
         node.state.fetch_or(0b10, SeqCst);
-        node.task.notify();
+        node.waker.wake();
     }
 }
 
@@ -257,8 +257,8 @@ impl Future for Timer {
     type Item = ();
     type Error = ();
 
-    fn poll(&mut self) -> Poll<(), ()> {
-        self.inner.task.register();
+    fn poll(&mut self, cx: &mut task::Context) -> Poll<(), ()> {
+        self.inner.waker.register(cx.waker());
         let mut list = self.inner.list.take();
         while let Some(node) = list.pop() {
             let at = *node.at.lock().unwrap();
@@ -267,7 +267,7 @@ impl Future for Timer {
                 None => self.remove(node),
             }
         }
-        Ok(Async::NotReady)
+        Ok(Async::Pending)
     }
 }
 

--- a/tests/interval.rs
+++ b/tests/interval.rs
@@ -4,6 +4,7 @@ extern crate futures_timer;
 use std::time::{Instant, Duration};
 
 use futures::prelude::*;
+use futures::executor::block_on;
 use futures_timer::Interval;
 
 #[test]
@@ -11,7 +12,7 @@ fn single() {
     let dur = Duration::from_millis(10);
     let start = Instant::now();
     let interval = Interval::new(dur);
-    interval.take(1).collect().wait().unwrap();
+    block_on(interval.take(1).collect()).unwrap();
     assert!(start.elapsed() >= dur);
 }
 
@@ -20,7 +21,7 @@ fn two_times() {
     let dur = Duration::from_millis(10);
     let start = Instant::now();
     let interval = Interval::new(dur);
-    let result = interval.take(2).collect().wait().unwrap();
+    let result = block_on(interval.take(2).collect()).unwrap();
     assert!(start.elapsed() >= dur*2);
     assert_eq!(result, vec![(), ()]);
 }

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -3,7 +3,7 @@ extern crate futures_timer;
 
 use std::time::{Instant, Duration};
 
-use futures::prelude::*;
+use futures::executor::block_on;
 use futures_timer::Delay;
 
 #[test]
@@ -11,7 +11,7 @@ fn smoke() {
     let dur = Duration::from_millis(10);
     let start = Instant::now();
     let timeout = Delay::new(dur);
-    timeout.wait().unwrap();
+    block_on(timeout).unwrap();
     assert!(start.elapsed() >= (dur / 2));
 }
 
@@ -19,7 +19,7 @@ fn smoke() {
 fn two() {
     let dur = Duration::from_millis(10);
     let timeout = Delay::new(dur);
-    timeout.wait().unwrap();
+    block_on(timeout).unwrap();
     let timeout = Delay::new(dur);
-    timeout.wait().unwrap();
+    block_on(timeout).unwrap();
 }


### PR DESCRIPTION
I'm experimenting with introducing futures 0.2 into the 0.12.x branch of hyper, where we're using `futures-timer`. In order to do that, I needed it to work with futures 0.2 :)

You probably don't want to merge this just yet, but maybe you'll find the time to review the changes so that this is ready to merge once futures 0.2 proper is released!